### PR TITLE
Resolve uwsm/env errors on Omarchy 3

### DIFF
--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -95,9 +95,6 @@ sed -i '/run_logged \$OMARCHY_INSTALL\/login\/alt-bootloaders\.sh/d' install/log
 # Remove pacman.sh from post-install/all.sh to prevent conflict with cachyos packages
 sed -i '/run_logged \$OMARCHY_INSTALL\/post-install\/pacman\.sh/d' install/post-install/all.sh
 
-# Set TERMINAL variable in config/uwsm/env (add after the initial exports)
-sed -i '/^export/aexport TERMINAL=ghostty' config/uwsm/env
-
 # Update mise activation to support both bash and fish
 sed -i 's/omarchy-cmd-present mise && eval "\$(mise activate bash)"/if [ "\$SHELL" = "\/bin\/bash" ] \&\& command -v mise \&> \/dev\/null; then\n  eval "\$(mise activate bash)"\nelif [ "\$SHELL" = "\/bin\/fish" ] \&\& command -v mise \&> \/dev\/null; then\n  mise activate fish | source\nfi/' config/uwsm/env
 


### PR DESCRIPTION
Omarchy 3.0 added `omarchy-cmd-present`, which broke the `sed` line looking for `command -v mise`.

We don't need to `export TERMINAL` anymore (plus it was getting exported twice). Omarchy 3.1.5 sets TERMINAL to `xdg-terminal-exec` in `config/uwsm/default`. Omarchy 3.2.0 adds a migration to do the same for prior installs.

Fixes https://github.com/mroboff/omarchy-on-cachyos/issues/20