### PR TITLE
Fix: Replace open-dkms NVIDIA drivers with 580xx

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ This project provides an installation script for implementing DHH's Omarchy conf
 
 This installation script does the following three things:
 
- 1) Clones Omarchy from its github repository 
- 2) Makes adjustments to the Omarchy install scripts to support installation on CachyOS
- 3) Launches the installation of Omarchy on an already setup CachyOS system
+  1) Clones Omarchy from its github repository 
+  2) Makes adjustments to the Omarchy install scripts to support installation on CachyOS
+  3) Launches the installation of Omarchy on an already setup CachyOS system
+  4) Installs and configures NVIDIA 580xx proprietary drivers
 
 This script does not:
- 
+
  1) Install CachyOS or any other Linux operating system
  2) Partition, format, or encrypt hard disks
  3) Install or configure a boot loader
- 4) Install graphics drivers
  5) Install or configure a login display manager
 
 All of the above need to be done when you install CachyOS. 
@@ -40,7 +40,9 @@ The philosophy behind this script is to produce a strong and stable blend of Cac
 
 5. Login System: As a distribution, Omarchy skips installation of a login display manager. Instead, Hyprland autostarts and password protection is provided upon boot by the LUKS full disk encryption service. This script, however, assumes a display manager is installed. (Note: this script does not install a display manager, but also does not configure Hyprland to start automatically if a display manager is not installed.)
 
-6. Full Disk Encryption: As a distribution, Omarchy automatically turns on full disk encryption via LUKS. This script, however, leaves this decision up to the user. CachyOS can be installed with or without full disk encryption, and this script will install Omarchy on either setup.  
+6. Full Disk Encryption: As a distribution, Omarchy automatically turns on full disk encryption via LUKS. This script, however, leaves this decision up to the user. CachyOS can be installed with or without full disk encryption, and this script will install Omarchy on either setup.
+
+7. NVIDIA Drivers: *By default, CachyOS and Omarchy may attempt to use the latest NVIDIA drivers with open kernel modules. This script explicitly downgrades/pins the driver to the* *580xx proprietary series* *using CachyOS's* `chwd` *tool. This is a deliberate choice to fix widespread issues with hardware acceleration, electron apps, and browser flickering.*
 
 ## 4. Pre-Requisites
 
@@ -52,7 +54,24 @@ IMPORTANT: This script does not install CachyOS. You must do that separately (an
 
 3. Desktop Environment to Install: You can install a minimal system with no desktop environment or you can choose to install the CachyOS Hyprland Desktop Environment. If you have CachyOS install Hyprland, it will also install SDDM as the login display manager by default. Do not install GNOME or KDE.
 
-4. Graphics Drivers for NVIDIA users: If you are using an NVIDIA GPU, install the recommended graphics driver via CachyOS. The script will turn off driver installation in Omarchy. 
+4. Graphics Drivers for NVIDIA users: 
+
+5. This script now automatically handles NVIDIA driver installation by enforcing the proprietary 580xx drivers (via CachyOS `chwd`). This is necessary to avoid known regressions with hardware video decoding and browser flickering present in the newer open-kernel module drivers.
+
+   **Important:** To fully enable hardware acceleration in Firefox, you must manually add the following overrides to your `user.js`:
+
+   ```js
+   // FORCE NVIDIA HARDWARE ACCELERATION
+   user_pref("media.hardware-video-decoding.force-enabled", true);
+   user_pref("media.hardware-video-encoding.force-enabled", true);
+   user_pref("layers.acceleration.force-enabled", true);
+   user_pref("webgl.force-enabled", true);
+   user_pref("media.ffmpeg.vaapi.enabled", true);
+   user_pref("media.rdd-ffmpeg.enabled", true);
+   user_pref("media.av1.enabled", true);
+   user_pref("widget.dmabuf.force-enabled", true);
+   user_pref("gfx.x11-egl.force-enabled", true);
+   ```
 
 Other configuration changes are up to you. Note, however, that this script has not been extensively tested on various CachyOS installations other than the author's own machine.
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,19 @@ IMPORTANT: This script does not install CachyOS. You must do that separately (an
 
 5. This script now automatically handles NVIDIA driver installation by enforcing the proprietary 580xx drivers (via CachyOS `chwd`). This is necessary to avoid known regressions with hardware video decoding and browser flickering present in the newer open-kernel module drivers.
 
-   **Important:** To fully enable hardware acceleration in Firefox, you must manually add the following overrides to your `user.js`:
+   **Important:** 
 
+   To enable hardware video decode via NVDEC in chromium, you must:
+   
+   1. Add the following to `~/.config/chromium-flags.conf`:       ```       --enable-features=VaapiOnNvidiaGPUs       ```
+   2. Install the [enhanced-h264ify extension](https://chromewebstore.google.com/detail/enhanced-h264ify/omkfmpieigblcllmkgbflkikinpkodlk) and disable **VP8** and **AV1** codecs.
+   
+   
+   
+   To fully enable hardware acceleration in Firefox, you must 
+   
+   1. Install the [enhanced-h264ify add-on](https://addons.mozilla.org/en-US/firefox/addon/enhanced-h264ify/) and disable **VP8** and **AV1** codecs and manually add the following overrides to your `user.js`:
+   
    ```js
    // FORCE NVIDIA HARDWARE ACCELERATION
    user_pref("media.hardware-video-decoding.force-enabled", true);

--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -80,8 +80,9 @@ sed -i '/linux-cachyos/ ! s/pacman -Q linux/pacman -Q linux-cachyos/' bin/omarch
 # Remove pacman.sh from preflight/all.sh to prevent conflict with cachyos packages
 sed -i '/run_logged \$OMARCHY_INSTALL\/preflight\/pacman\.sh/d' install/preflight/all.sh
 
-# Remove nvidia.sh source line from install.sh
-sed -i '/run_logged \$OMARCHY_INSTALL\/config\/hardware\/nvidia\.sh/d' install/config/all.sh
+# Replace nvidia.sh with custom CachyOS 580xx Driver Logic
+cp ../bin/nvidia.sh install/config/hardware/nvidia.sh
+chmod +x install/config/hardware/nvidia.sh
 
 # Remove plymouth.sh source line from install.sh
 sed -i '/run_logged \$OMARCHY_INSTALL\/login\/plymouth\.sh/d' install/login/all.sh
@@ -109,7 +110,7 @@ echo "The following adjustments have been completed."
 echo " 1. Added Omarchy repo to pacman.conf"
 echo " 2. Removed tldr from packages.sh to avoid conflict with tealdeer on CachyOS."
 echo " 3. Disabled further Omarchy changes to pacman.conf, preserving CachyOS settings."
-echo " 4. Removed nvidia.sh from install.sh to avoid conflict with CachyOS graphics driver installation."
+echo " 4. Replaced nvidia.sh with custom CachyOS 580xx Driver Logic."
 echo " 5. Removed plymouth.sh from install.sh to avoid conflict with CachyOS login display manager installation."
 echo " 6. Removed limine-snapper.sh from install.sh to avoid conflict with CachyOS boot loader installation."
 echo " 7. Removed alt-bootloaders.sh from install.sh to avoid conflict with CachyOS boot loader installation."

--- a/bin/nvidia.sh
+++ b/bin/nvidia.sh
@@ -34,7 +34,10 @@ sudo chwd -r nvidia-open-dkms --noconfirm || true
 echo "[*] Installing 580xx proprietary profile..."
 sudo chwd -a
 
-# 6. Add NVIDIA environment variables for UWSM
+# 6. Install VA-API utils
+sudo pacman -S --needed --noconfirm libva-utils
+
+# 7. Add NVIDIA environment variables for UWSM
 cat >>$HOME/.config/uwsm/env <<'EOF'
 
 # NVIDIA

--- a/bin/nvidia.sh
+++ b/bin/nvidia.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+# 1. Get GPU ID
+GPU_ID=$(lspci -nn -d 10de: | grep -E "VGA|3D" | head -n1 | grep -oP '(?<=\[10de:)[0-9a-fA-F]{4}(?=\])')
+
+if [[ -z "$GPU_ID" ]]; then
+    echo "No NVIDIA GPU found. Skipping."
+    exit 0
+fi
+
+echo "[*] Found NVIDIA ID: $GPU_ID"
+
+# 2. Kill the conflicts
+echo "[*] Removing conflicting open-driver packages..."
+sudo pacman -Rdd --noconfirm libxnvctrl linux-cachyos-nvidia-open linux-cachyos-lts-nvidia-open nvidia-open-dkms 2>/dev/null || true
+
+# 3. Patch the file
+if ! grep -q "$GPU_ID" /var/lib/chwd/ids/nvidia-580.ids; then
+    echo "[*] Patching chwd ID list..."
+    if [ -n "$(tail -c1 /var/lib/chwd/ids/nvidia-580.ids)" ]; then
+        sudo sh -c "echo >> /var/lib/chwd/ids/nvidia-580.ids"
+    fi
+    sudo sed -i "\$a $GPU_ID" /var/lib/chwd/ids/nvidia-580.ids
+else
+    echo "[*] GPU ID already present in 580 list."
+fi
+
+# 4. Remove old profile
+echo "[*] Removing old chwd profile..."
+sudo chwd -r nvidia-open-dkms --noconfirm || true
+
+# 5. Install new profile
+echo "[*] Installing 580xx proprietary profile..."
+sudo chwd -a
+
+# 6. Add NVIDIA environment variables for UWSM
+cat >>$HOME/.config/uwsm/env <<'EOF'
+
+# NVIDIA
+export LIBVA_DRIVER_NAME=nvidia
+export GBM_BACKEND=nvidia-drm
+export __GLX_VENDOR_LIBRARY_NAME=nvidia
+export NVD_BACKEND=direct
+export MOZ_DISABLE_RDD_SANDBOX=1
+export CUDA_DISABLE_PERF_BOOST=1
+EOF


### PR DESCRIPTION
The only working solution I found to [#3899](https://github.com/basecamp/omarchy/issues/3899) and [#4055](https://github.com/basecamp/omarchy/discussions/4055)

Now install-omarchy-on-cachyos.sh is replacing /install/config/hardware/nvidia.sh with my /bin/nvidia.sh that:
1. adds the GPU ID to the 580xx chwd list
2. removes conflicting packages
3. removes open-dkms chwd profile
4. install 580xx chwd profile
5. appends correct environment variables to ~/.config/uwsm/env