### PR TITLE
Fix CachyOS installer: WiFi, walker, and nvidia issues

### DIFF
--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -109,6 +109,37 @@ sed -i '/run_logged \$OMARCHY_INSTALL\/login\/alt-bootloaders\.sh/d' install/log
 # Remove pacman.sh from post-install/all.sh to prevent conflict with cachyos packages
 sed -i '/run_logged \$OMARCHY_INSTALL\/post-install\/pacman\.sh/d' install/post-install/all.sh
 
+# Disable wpa_supplicant and configure NetworkManager to use iwd backend.
+# CachyOS enables wpa_supplicant by default, which conflicts with omarchy's iwd,
+# causing WiFi to appear connected but have no IP or connectivity.
+cat >> install/config/hardware/network.sh << 'NETEOF'
+
+# Disable wpa_supplicant to prevent conflict with iwd
+sudo systemctl disable --now wpa_supplicant.service 2>/dev/null
+
+# Configure NetworkManager to use iwd as its WiFi backend
+if ! grep -q "wifi.backend=iwd" /etc/NetworkManager/NetworkManager.conf 2>/dev/null; then
+  sudo tee -a /etc/NetworkManager/NetworkManager.conf > /dev/null << EOF
+
+[device]
+wifi.backend=iwd
+EOF
+fi
+NETEOF
+
+# Pin walker to the omarchy repo so CachyOS doesn't override it with an
+# incompatible version that breaks compatibility with elephant.
+sed -i '1a\
+# Pin walker to omarchy repo to prevent CachyOS version conflict\
+if ! grep -q "^IgnorePkg.*walker" /etc/pacman.conf 2>/dev/null; then\
+  if grep -q "^IgnorePkg" /etc/pacman.conf; then\
+    sudo sed -i '"'"'s/^IgnorePkg = \\(.*\\)/IgnorePkg = \\1 walker/'"'"' /etc/pacman.conf\
+  else\
+    sudo sed -i '"'"'/^\\[options\\]/a IgnorePkg = walker'"'"' /etc/pacman.conf\
+  fi\
+fi\
+' install/config/walker-elephant.sh
+
 # Update mise activation to support both bash and fish
 sed -i 's/omarchy-cmd-present mise && eval "\$(mise activate bash)"/if [ "\$SHELL" = "\/bin\/bash" ] \&\& command -v mise \&> \/dev\/null; then\n  eval "\$(mise activate bash)"\nelif [ "\$SHELL" = "\/bin\/fish" ] \&\& command -v mise \&> \/dev\/null; then\n  mise activate fish | source\nfi/' config/uwsm/env
 
@@ -128,6 +159,8 @@ echo " 5. Removed plymouth.sh from install.sh to avoid conflict with CachyOS log
 echo " 6. Removed limine-snapper.sh from install.sh to avoid conflict with CachyOS boot loader installation."
 echo " 7. Removed alt-bootloaders.sh from install.sh to avoid conflict with CachyOS boot loader installation."
 echo " 8. Removed /etc/sddm.conf to avoid conflict with Omarchy UWSM session autologin."
+echo " 9. Disabled wpa_supplicant and configured NetworkManager to use iwd backend."
+echo "10. Pinned walker to omarchy repo to prevent CachyOS version conflict."
 echo ""
 echo "IMPORTANT: If you installed CachyOS without a deskop environment, you will not have a display manager installed." 
 echo "If this is the case, you will need to run the following command after this installation script is complete:"

--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -46,8 +46,12 @@ sudo pacman-key --recv-keys F0134EE680CAC571
 # Locally sign and trust the key
 sudo pacman-key --lsign-key F0134EE680CAC571
 
-# Add omarchy repository to pacman.conf
-echo -e "\n[omarchy]\nSigLevel = Optional TrustedOnly\nServer = https://pkgs.omarchy.org/\$arch" | sudo tee -a /etc/pacman.conf > /dev/null
+# Add omarchy repository to pacman.conf (skip if already present)
+if ! grep -q '^\[omarchy\]' /etc/pacman.conf; then
+    echo -e "\n[omarchy]\nSigLevel = Optional TrustedOnly\nServer = https://pkgs.omarchy.org/\$arch" | sudo tee -a /etc/pacman.conf > /dev/null
+else
+    echo "Omarchy repository already present in pacman.conf, skipping."
+fi
 sudo pacman -Syu
 
 # Remove CachyOS SDDM config
@@ -89,6 +93,9 @@ sed -i '/run_logged \$OMARCHY_INSTALL\/preflight\/pacman\.sh/d' install/prefligh
 # Replace nvidia.sh with custom CachyOS 580xx Driver Logic
 cp ../bin/nvidia.sh install/config/hardware/nvidia.sh
 chmod +x install/config/hardware/nvidia.sh
+
+# Fix omarchy-ai-skill.sh symlink to be idempotent on re-runs
+sed -i 's/ln -s/ln -sf/' install/config/omarchy-ai-skill.sh
 
 # Remove plymouth.sh source line from install.sh
 sed -i '/run_logged \$OMARCHY_INSTALL\/login\/plymouth\.sh/d' install/login/all.sh

--- a/bin/nvidia.sh
+++ b/bin/nvidia.sh
@@ -2,7 +2,7 @@
 set -e
 
 # 1. Get GPU ID
-GPU_ID=$(lspci -nn -d 10de: | grep -E "VGA|3D" | head -n1 | grep -oP '(?<=\[10de:)[0-9a-fA-F]{4}(?=\])')
+GPU_ID=$(lspci -nn -d 10de: | grep -E "VGA|3D" | head -n1 | grep -oP '(?<=\[10de:)[0-9a-fA-F]{4}(?=\])' || true)
 
 if [[ -z "$GPU_ID" ]]; then
     echo "No NVIDIA GPU found. Skipping."


### PR DESCRIPTION
Context

This started as an effort to resolve https://github.com/mroboff/omarchy-on-cachyos/issues/30 (nvidia script failures on fresh installs). While troubleshooting that on my personal, freshCachyOS install, uncovered additional conflicts between CachyOS defaults and omarchy that turned out to be more widespread than just one machine — https://github.com/mroboff/omarchy-on-cachyos/issues/26 reports the same WiFi issue on a Dell XPS, and https://github.com/mroboff/omarchy-on-cachyos/issues/29 hits the same omarchy-ai-skill.sh symlink failure on re-runs.
Summary

    Nvidia: Fix installer crashes on re-runs by improving idempotency in nvidia.sh. Addresses https://github.com/mroboff/omarchy-on-cachyos/issues/30.
    WiFi: Disable wpa_supplicant and configure NetworkManager to use iwd backend. CachyOS enables wpa_supplicant by default, which conflicts with omarchy's iwd — causing WiFi to appear connected but have no IP or connectivity. Addresses https://github.com/mroboff/omarchy-on-cachyos/issues/26.
    Walker: Pin walker to the omarchy repo via IgnorePkg so CachyOS doesn't override it with a newer version that breaks elephant compatibility. Without this, the app launcher opens empty and crashes.
    omarchy-ai-skill.sh: Already patched in the installer (ln -s → ln -sf) for idempotent re-runs. Addresses https://github.com/mroboff/omarchy-on-cachyos/issues/29.

Test plan

    Fresh install on CachyOS with WiFi — verify wpa_supplicant is disabled and NM uses iwd backend
    Verify pacman -Syu does not upgrade walker from the cachyos repo
    Verify walker launches and shows desktop applications
    Re-run installer to confirm nvidia.sh and omarchy-ai-skill.sh idempotency