### PR TITLE
Fix/install issues keyserver fallback, SDDM autologin user, claude-code conflict, nvidia package checks

### DIFF
--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -40,11 +40,20 @@ else
     echo "yay is already installed."
 fi
 
-# Receive the Omarchy signing key
-sudo pacman-key --recv-keys F0134EE680CAC571
+# Receive the Omarchy signing key (try multiple keyservers)
+OMARCHY_KEY=F0134EE680CAC571
+for ks in hkps://keyserver.ubuntu.com hkps://keys.openpgp.org hkp://keyserver.ubuntu.com:80; do
+    echo "Trying keyserver: $ks"
+    sudo pacman-key --keyserver "$ks" --recv-keys "$OMARCHY_KEY" && break
+done
+
+if ! sudo pacman-key --list-keys "$OMARCHY_KEY" &>/dev/null; then
+    echo "Error: Failed to import omarchy signing key from all keyservers."
+    exit 1
+fi
 
 # Locally sign and trust the key
-sudo pacman-key --lsign-key F0134EE680CAC571
+sudo pacman-key --lsign-key "$OMARCHY_KEY"
 
 # Add omarchy repository to pacman.conf (skip if already present)
 if ! grep -q '^\[omarchy\]' /etc/pacman.conf; then
@@ -143,6 +152,10 @@ fi\
 # Update mise activation to support both bash and fish
 sed -i 's/omarchy-cmd-present mise && eval "\$(mise activate bash)"/if [ "\$SHELL" = "\/bin\/bash" ] \&\& command -v mise \&> \/dev\/null; then\n  eval "\$(mise activate bash)"\nelif [ "\$SHELL" = "\/bin\/fish" ] \&\& command -v mise \&> \/dev\/null; then\n  mise activate fish | source\nfi/' config/uwsm/env
 
+# Fix SDDM autologin to use the intended username instead of $USER.
+# The install runs as root, so without this fix autologin.conf gets User=root.
+sed -i "s/User=\\\$USER/User=$OMARCHY_USER_NAME/" install/login/sddm.sh
+
 # Copy omarchy installation files to ~/.local/share/omarchy
 mkdir -p ~/.local/share/omarchy
 cp -r . ~/.local/share/omarchy
@@ -171,6 +184,16 @@ echo ""
 echo "Press Enter to begin the installation of Omarchy..."
 read -r
 
-# Run the modified install.sh script 
+# Remove existing claude-code to prevent file conflict during omarchy install
+# (CachyOS may have installed it separately; pacman will fail if /usr/bin/claude already exists)
+if pacman -Q claude-code &>/dev/null 2>&1; then
+    echo "Removing existing claude-code package to avoid file conflict..."
+    sudo pacman -Rdd --noconfirm claude-code
+elif [ -f /usr/bin/claude ]; then
+    echo "Removing existing /usr/bin/claude to avoid file conflict..."
+    sudo rm -f /usr/bin/claude
+fi
+
+# Run the modified install.sh script
 chmod +x install.sh
 ./install.sh

--- a/bin/nvidia.sh
+++ b/bin/nvidia.sh
@@ -13,7 +13,12 @@ echo "[*] Found NVIDIA ID: $GPU_ID"
 
 # 2. Kill the conflicts
 echo "[*] Removing conflicting open-driver packages..."
-sudo pacman -Rdd --noconfirm libxnvctrl linux-cachyos-nvidia-open linux-cachyos-lts-nvidia-open nvidia-open-dkms 2>/dev/null || true
+for pkg in libxnvctrl nvidia-open-dkms linux-cachyos-nvidia-open linux-cachyos-lts-nvidia-open; do
+    if pacman -Q "$pkg" &>/dev/null 2>&1; then
+        echo "[*] Removing $pkg..."
+        sudo pacman -Rdd --noconfirm "$pkg" || true
+    fi
+done
 
 # 3. Patch the file
 if ! grep -q "$GPU_ID" /var/lib/chwd/ids/nvidia-580.ids; then
@@ -26,9 +31,9 @@ else
     echo "[*] GPU ID already present in 580 list."
 fi
 
-# 4. Remove old profile
+# 4. Remove old profile (chwd does not accept --noconfirm)
 echo "[*] Removing old chwd profile..."
-sudo chwd -r nvidia-open-dkms --noconfirm || true
+sudo chwd -r nvidia-open-dkms || true
 
 # 5. Install new profile
 echo "[*] Installing 580xx proprietary profile..."


### PR DESCRIPTION
# Fix installer crashes: keyserver fallback, SDDM autologin user, claude-code conflict, nvidia package checks

## Background

These fixes come from actually running the installer end-to-end on a fresh CachyOS system. Five bugs caused hard crashes or silent misconfigurations that only surface during a real install — none of them are visible in a dry-run or code review. They are documented here in the order you hit them.

One lesson learned the hard way: **attempting this install from a CachyOS minimal/no-GUI system is not worth it.** The installer assumes a running Wayland session (for `hyprctl`, `wl-paste`, SDDM already configured, etc.). Start from **CachyOS with the Hyprland desktop environment pre-installed** — that is the only baseline that has been tested and where everything works as expected.

---

## Bugs Fixed

### 1. `pacman-key --recv-keys` fails silently when keyserver is unreachable

**Script:** `install-omarchy-on-cachyos.sh`

**What happened:** The default keyserver (`keys.gnupg.net`) is frequently unreachable or rate-limited. The single `pacman-key --recv-keys` call would fail with no retry, leaving the Omarchy signing key unimported. Every subsequent `pacman` operation against the `[omarchy]` repository would then fail with a signature verification error, halting the install.

**Fix:** The key import now loops over three keyservers (`keyserver.ubuntu.com` over HKPS, `keys.openpgp.org`, and `keyserver.ubuntu.com` over plain HKP port 80 as a last resort). It breaks on the first success. If all three fail, the script exits with a clear error instead of continuing into a broken state.

```bash
# Before
sudo pacman-key --recv-keys F0134EE680CAC571

# After
OMARCHY_KEY=F0134EE680CAC571
for ks in hkps://keyserver.ubuntu.com hkps://keys.openpgp.org hkp://keyserver.ubuntu.com:80; do
    sudo pacman-key --keyserver "$ks" --recv-keys "$OMARCHY_KEY" && break
done
if ! sudo pacman-key --list-keys "$OMARCHY_KEY" &>/dev/null; then
    echo "Error: Failed to import omarchy signing key from all keyservers."
    exit 1
fi
```

---

### 2. SDDM autologin configured as `User=root`

**Script:** `install-omarchy-on-cachyos.sh`

**What happened:** Omarchy's `install/login/sddm.sh` writes `/etc/sddm.conf.d/autologin.conf` with `User=$USER`. Because the installer runs as root (via `sudo`), `$USER` expands to `root` at the time the sed patch is applied. The result: SDDM autologin tries to start a Hyprland session as root, which Hyprland refuses. The machine boots to a broken login loop.

**Fix:** Before copying the Omarchy tree, the script patches `install/login/sddm.sh` to replace `$USER` with the value of `$OMARCHY_USER_NAME` (already set earlier in the script to the actual non-root user). This happens at patch time, before `install.sh` runs, so the written config contains the correct username.

```bash
# Fix SDDM autologin to use the intended username instead of $USER.
# The install runs as root, so without this fix autologin.conf gets User=root.
sed -i "s/User=\$USER/User=$OMARCHY_USER_NAME/" install/login/sddm.sh
```

---

### 3. `pacman` aborts with file conflict on `/usr/bin/claude`

**Script:** `install-omarchy-on-cachyos.sh`

**What happened:** CachyOS ships `claude-code` in its repositories. If the user installed it (or it was pulled in as a dependency), `/usr/bin/claude` already exists on the system. When Omarchy's `install.sh` runs and tries to install its own `claude-code` package, `pacman` detects a file conflict and aborts. This happens near the end of the install, after all other packages are already installed, making it both surprising and disruptive.

**Fix:** Just before running `install.sh`, the script checks for and removes any existing `claude-code` installation. It handles both the case where the full package is installed (uses `pacman -Rdd` to skip dependency checks) and the case where only the binary exists as a stray file.

```bash
if pacman -Q claude-code &>/dev/null 2>&1; then
    sudo pacman -Rdd --noconfirm claude-code
elif [ -f /usr/bin/claude ]; then
    sudo rm -f /usr/bin/claude
fi
```

---

### 4. `nvidia.sh` crashes when open-driver packages are not installed

**Script:** `nvidia.sh`

**What happened:** The original removal command listed all four conflicting packages in a single `pacman -Rdd` call with `2>/dev/null || true`. If any of the packages were not installed (e.g., on a fresh minimal CachyOS without the Hyprland desktop), `pacman` exits non-zero for the whole batch. The `|| true` masked this — but on some system configurations, `set -e` or wrapper logic caused the script to abort prematurely.

**Fix:** Each package is checked individually with `pacman -Q` before attempting removal. This is explicit, avoids suppressing real errors with a blanket `|| true`, and produces clear per-package output for debugging.

```bash
for pkg in libxnvctrl nvidia-open-dkms linux-cachyos-nvidia-open linux-cachyos-lts-nvidia-open; do
    if pacman -Q "$pkg" &>/dev/null 2>&1; then
        echo "[*] Removing $pkg..."
        sudo pacman -Rdd --noconfirm "$pkg" || true
    fi
done
```

---

### 5. `chwd -r` rejects `--noconfirm` flag and exits non-zero

**Script:** `nvidia.sh`

**What happened:** The call to remove the old NVIDIA profile passed `--noconfirm` to `chwd`. Unlike `pacman`, `chwd` does not recognize this flag and exits with an error. Since this step ran before the profile install, the script would abort before the proprietary 580xx driver was ever installed, leaving the system in an inconsistent state with no working NVIDIA driver.

**Fix:** Remove the invalid flag. `chwd -r` is interactive but only when there is something to confirm — on a system where the profile is already absent (idempotent re-run), it exits cleanly. The `|| true` is kept to handle the absent-profile case.

```bash
# Before
sudo chwd -r nvidia-open-dkms --noconfirm || true

# After
sudo chwd -r nvidia-open-dkms || true
```

---

## Recommended Installation Baseline

Install CachyOS with the **Hyprland desktop environment** selected during setup. This gives you:

- SDDM already installed and running
- The Fish shell as default (required)
- A working Wayland session to verify the result
- `hyprctl` available for monitor detection in post-install scripts

Installing from a minimal/no-GUI CachyOS system requires manually resolving session, display manager, and shell assumptions baked into the Omarchy installer. It is possible but significantly more painful and has not been tested as a supported path.
