### PR TITLE
Feat/version selection, allow select stable versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project provides an installation script for implementing DHH's Omarchy conf
 
 This installation script does the following three things:
 
-  1) Clones Omarchy from its github repository 
+  1) Prompts for and fetches your preferred version of Omarchy (Stable tags or Bleeding Edge)
   2) Makes adjustments to the Omarchy install scripts to support installation on CachyOS
   3) Launches the installation of Omarchy on an already setup CachyOS system
   4) Installs and configures NVIDIA 580xx proprietary drivers

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # omarchy-on-cachyos
 
-UPDATE 20-May-2026: The install script now includes interactive version selection for choosing between Stable releases and Bleeding Edge.
-UPDATE 1-October-2025: The install script has been updated to support Omarchy 3.0+ out of the box. 
+- UPDATE 20-May-2026: The install script now includes interactive version selection for choosing between Stable releases and Bleeding Edge.
+- UPDATE 1-October-2025: The install script has been updated to support Omarchy 3.0+ out of the box.
 
 ## 1. Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # omarchy-on-cachyos
 
+UPDATE 20-May-2026: The install script now includes interactive version selection for choosing between Stable releases and Bleeding Edge.
 UPDATE 1-October-2025: The install script has been updated to support Omarchy 3.0+ out of the box. 
 
 ## 1. Introduction

--- a/bin/fetch-omarchy.sh
+++ b/bin/fetch-omarchy.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Target destination
+TARGET_DIR="../omarchy"
+REPO_URL="https://github.com/basecamp/omarchy"
+
+# Fetch available stable version tags from the remote repository cleanly
+echo "Fetching available stable releases from GitHub..."
+RELEASES=($(git ls-remote --tags --refs $REPO_URL 2>/dev/null | awk -F/ '{print $3}' | sort -rV | head -n 5))
+
+echo "-----------------------------------------------"
+echo "Select the Omarchy version you want to install:"
+echo "-----------------------------------------------"
+echo "1) Bleeding Edge (dev/main branch - Unstable)"
+
+# Dynamically list the stable versions fetched from the repository
+for i in "${!RELEASES[@]}"; do
+    echo "$((i+2))) Stable Release (${RELEASES[i]})"
+done
+
+read -r -p "Enter your choice (1-$(( ${#RELEASES[@]} + 1 ))): " CHOICE
+
+# Formulate arguments based on selection
+if [ "$CHOICE" -eq 1 ] || [ -z "$CHOICE" ]; then
+    BRANCH_ARGS=""
+    echo "Cloning bleeding-edge dev tree..."
+else
+    SELECTED_TAG="${RELEASES[$((CHOICE-2))]}"
+    BRANCH_ARGS="--depth 1 -b $SELECTED_TAG"
+    echo "Cloning stable version: $SELECTED_TAG..."
+fi
+
+# Ensure target directory is clean before git cloning to prevent fatal conflicts
+if [ -d "$TARGET_DIR" ]; then
+    echo ""
+    echo "⚠️ Warning: An existing installation directory was found at $TARGET_DIR"
+    read -r -p "Would you like to delete it and proceed with a clean install? [y/N]: " CONFIRM
+    
+    if [[ "${CONFIRM,,}" =~ ^(y|yes)$ ]]; then
+        echo "Cleaning up previous installation files at $TARGET_DIR..."
+        rm -rf "$TARGET_DIR"
+    else
+        echo "Installation aborted by user to preserve existing directory."
+        exit 1
+    fi
+fi
+
+# Execute clean, quiet checkout bypassing standard detached HEAD advice warnings
+if ! git -c advice.detachedHead=false clone --quiet $BRANCH_ARGS $REPO_URL "$TARGET_DIR"; then
+    echo "Error: Failed to clone Omarchy repo."
+    exit 1
+fi
+
+echo "Successfully cloned Omarchy repository layout."

--- a/bin/fetch-omarchy.sh
+++ b/bin/fetch-omarchy.sh
@@ -34,19 +34,21 @@ fi
 # Ensure target directory is clean before git cloning to prevent fatal conflicts
 if [ -d "$TARGET_DIR" ]; then
     echo ""
-    echo "⚠️ Warning: An existing installation directory was found at $TARGET_DIR"
+    echo "⚠️  Warning: An existing installation directory was found at $TARGET_DIR"
     read -r -p "Would you like to delete it and proceed with a clean install? [y/N]: " CONFIRM
     
     if [[ "${CONFIRM,,}" =~ ^(y|yes)$ ]]; then
         echo "Cleaning up previous installation files at $TARGET_DIR..."
         rm -rf "$TARGET_DIR"
     else
-        echo "Installation aborted by user to preserve existing directory."
-        exit 1
+        echo "Proceeding with existing files in $TARGET_DIR..."
+        # If user chooses not to delete, we should skip the clone but continue the script
+        exit 0
     fi
 fi
 
 # Execute clean, quiet checkout bypassing standard detached HEAD advice warnings
+echo "Cloning into $TARGET_DIR..."
 if ! git -c advice.detachedHead=false clone --quiet $BRANCH_ARGS $REPO_URL "$TARGET_DIR"; then
     echo "Error: Failed to clone Omarchy repo."
     exit 1

--- a/bin/fetch-omarchy.sh
+++ b/bin/fetch-omarchy.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# Target destination
-TARGET_DIR="../omarchy"
+# Target destination (relative to this script's location)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_DIR="$SCRIPT_DIR/../../omarchy"
 REPO_URL="https://github.com/basecamp/omarchy"
 
 # Fetch available stable version tags from the remote repository cleanly

--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -8,17 +8,20 @@ fi
 
 # Fetch Omarchy from repo
 echo "Fetching Omarchy source..."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OMARCHY_DIR="$SCRIPT_DIR/../../omarchy"
+
 if [ -f "./fetch-omarchy.sh" ]; then
     chmod +x ./fetch-omarchy.sh
     ./fetch-omarchy.sh
 else
     # Fallback if script is missing
     echo "fetch-omarchy.sh not found, falling back to default clone..."
-    git clone https://www.github.com/basecamp/omarchy ../omarchy
+    git clone https://www.github.com/basecamp/omarchy "$OMARCHY_DIR"
 fi
 
-if [ ! -d "../omarchy" ]; then
-    echo "Error: Failed to fetch Omarchy source."
+if [ ! -d "$OMARCHY_DIR" ]; then
+    echo "Error: Failed to fetch Omarchy source at $OMARCHY_DIR"
     exit 1
 fi
 

--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -6,13 +6,20 @@ if ! command -v git &> /dev/null; then
     exit 1
 fi
 
-# Clone omarchyy from repo
-echo "Clone Omarchy from repo..."
-if ! git clone https://www.github.com/basecamp/omarchy ../omarchy; then
-    echo "Error: Failed to clone Omarchy repo."
+# Fetch Omarchy from repo
+echo "Fetching Omarchy source..."
+if [ -f "./bin/fetch-omarchy.sh" ]; then
+    bash ./bin/fetch-omarchy.sh
+else
+    # Fallback if script is missing or run from different dir
+    echo "fetch-omarchy.sh not found, falling back to default clone..."
+    git clone https://www.github.com/basecamp/omarchy ../omarchy
 fi
 
-echo "Successfully extracted omarchy archive."
+if [ ! -d "../omarchy" ]; then
+    echo "Error: Failed to fetch Omarchy source."
+    exit 1
+fi
 
 # Check if yay is installed
 if ! command -v yay &> /dev/null; then

--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -8,10 +8,11 @@ fi
 
 # Fetch Omarchy from repo
 echo "Fetching Omarchy source..."
-if [ -f "./bin/fetch-omarchy.sh" ]; then
-    bash ./bin/fetch-omarchy.sh
+if [ -f "./fetch-omarchy.sh" ]; then
+    chmod +x ./fetch-omarchy.sh
+    ./fetch-omarchy.sh
 else
-    # Fallback if script is missing or run from different dir
+    # Fallback if script is missing
     echo "fetch-omarchy.sh not found, falling back to default clone..."
     git clone https://www.github.com/basecamp/omarchy ../omarchy
 fi


### PR DESCRIPTION
  This PR adds a version selection menu to the installer, allowing users to choose between stable releases or the
  bleeding-edge branch. 

  Key Changes:
   - Interactive Versioning: Added fetch-omarchy.sh to fetch real-time stable tags from GitHub, offering a choice between
     stable releases and the bleeding-edge main branch.
  

Tested: Verified locally by successfully fetching and cloning Omarchy v3.8.1.
[Test_cloning_3.8.1.txt](https://github.com/user-attachments/files/28071035/Test_cloning_3.8.1.txt)

