### PR TITLE
Fix pathing issues in install-omarchy-on-cachyos.sh

### DIFF
--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -88,7 +88,7 @@ echo ""
 echo "Making adjustments to Omarchy install scripts to support CachyOS..."
 
 # Navigate to Omarchy install scripts
-cd ../omarchy
+cd "$OMARCHY_DIR"
 
 # Remove tldr installation to prevent conflict with tealdeer install.
 sed -i '/tldr/d' install/omarchy-base.packages
@@ -102,7 +102,7 @@ sed -i '/linux-cachyos/ ! s/pacman -Q linux/pacman -Q linux-cachyos/' bin/omarch
 sed -i '/run_logged \$OMARCHY_INSTALL\/preflight\/pacman\.sh/d' install/preflight/all.sh
 
 # Replace nvidia.sh with custom CachyOS 580xx Driver Logic
-cp ../bin/nvidia.sh install/config/hardware/nvidia.sh
+cp "$SCRIPT_DIR/nvidia.sh" install/config/hardware/nvidia.sh
 chmod +x install/config/hardware/nvidia.sh
 
 # Fix omarchy-ai-skill.sh symlink to be idempotent on re-runs


### PR DESCRIPTION
Hi! 

While testing the installation by strictly following the `README.md` steps and executing the script from the repository's `bin` folder, I noticed that the `install-omarchy-on-cachyos.sh` script fails to complete.

The script relies on relative paths (`cd ../omarchy` and `cp ../bin/...`), which break depending on the current working directory from which the script is executed.

I replaced these relative paths with the absolute directory variables that are already defined at the top of the script (`$OMARCHY_DIR` and `$SCRIPT_DIR`). 

This small change makes the script robust, ensuring it points to the correct directories regardless of where it is executed from. I have tested these changes locally and the installation now finishes successfully. 

Thanks!