### PR TITLE
fix: stabilize installer path handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.tmp/
 omarchy/

--- a/bin/fetch-omarchy.sh
+++ b/bin/fetch-omarchy.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-# Target destination (relative to this script's location)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TARGET_DIR="$SCRIPT_DIR/../../omarchy"
+set -euo pipefail
+
+if [ -z "${OMARCHY_WORK_DIR:-}" ]; then
+    echo "Error: OMARCHY_WORK_DIR is not set. Run this script from install-omarchy-on-cachyos.sh."
+    exit 1
+fi
+
 REPO_URL="https://github.com/basecamp/omarchy"
 
 # Fetch available stable version tags from the remote repository cleanly
@@ -32,24 +36,25 @@ else
 fi
 
 # Ensure target directory is clean before git cloning to prevent fatal conflicts
-if [ -d "$TARGET_DIR" ]; then
+if [ -d "$OMARCHY_WORK_DIR" ]; then
     echo ""
-    echo "⚠️  Warning: An existing installation directory was found at $TARGET_DIR"
+    echo "Warning: An existing installation directory was found at $OMARCHY_WORK_DIR"
     read -r -p "Would you like to delete it and proceed with a clean install? [y/N]: " CONFIRM
     
     if [[ "${CONFIRM,,}" =~ ^(y|yes)$ ]]; then
-        echo "Cleaning up previous installation files at $TARGET_DIR..."
-        rm -rf "$TARGET_DIR"
+        echo "Cleaning up previous installation files at $OMARCHY_WORK_DIR..."
+        rm -rf "$OMARCHY_WORK_DIR"
     else
-        echo "Proceeding with existing files in $TARGET_DIR..."
+        echo "Proceeding with existing files in $OMARCHY_WORK_DIR..."
         # If user chooses not to delete, we should skip the clone but continue the script
         exit 0
     fi
 fi
 
 # Execute clean, quiet checkout bypassing standard detached HEAD advice warnings
-echo "Cloning into $TARGET_DIR..."
-if ! git -c advice.detachedHead=false clone --quiet $BRANCH_ARGS $REPO_URL "$TARGET_DIR"; then
+mkdir -p "$(dirname "$OMARCHY_WORK_DIR")"
+echo "Cloning into $OMARCHY_WORK_DIR..."
+if ! git -c advice.detachedHead=false clone --quiet $BRANCH_ARGS $REPO_URL "$OMARCHY_WORK_DIR"; then
     echo "Error: Failed to clone Omarchy repo."
     exit 1
 fi

--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OMARCHY_WORK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/.tmp/omarchy"
+OMARCHY_INSTALL_DIR="$HOME/.local/share/omarchy"
+
+export OMARCHY_WORK_DIR
+
 # Check if git is installed
 if ! command -v git &> /dev/null; then
     echo "Error: git is not installed. Please install git before running this script."
@@ -8,20 +16,19 @@ fi
 
 # Fetch Omarchy from repo
 echo "Fetching Omarchy source..."
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-OMARCHY_DIR="$SCRIPT_DIR/../../omarchy"
 
-if [ -f "./fetch-omarchy.sh" ]; then
-    chmod +x ./fetch-omarchy.sh
-    ./fetch-omarchy.sh
+if [ -f "$SCRIPT_DIR/fetch-omarchy.sh" ]; then
+    chmod +x "$SCRIPT_DIR/fetch-omarchy.sh"
+    "$SCRIPT_DIR/fetch-omarchy.sh"
 else
     # Fallback if script is missing
     echo "fetch-omarchy.sh not found, falling back to default clone..."
-    git clone https://www.github.com/basecamp/omarchy "$OMARCHY_DIR"
+    mkdir -p "$(dirname "$OMARCHY_WORK_DIR")"
+    git clone https://www.github.com/basecamp/omarchy "$OMARCHY_WORK_DIR"
 fi
 
-if [ ! -d "$OMARCHY_DIR" ]; then
-    echo "Error: Failed to fetch Omarchy source at $OMARCHY_DIR"
+if [ ! -d "$OMARCHY_WORK_DIR" ]; then
+    echo "Error: Failed to fetch Omarchy source at $OMARCHY_WORK_DIR"
     exit 1
 fi
 
@@ -88,7 +95,7 @@ echo ""
 echo "Making adjustments to Omarchy install scripts to support CachyOS..."
 
 # Navigate to Omarchy install scripts
-cd ../omarchy
+cd "$OMARCHY_WORK_DIR"
 
 # Remove tldr installation to prevent conflict with tealdeer install.
 sed -i '/tldr/d' install/omarchy-base.packages
@@ -102,7 +109,7 @@ sed -i '/linux-cachyos/ ! s/pacman -Q linux/pacman -Q linux-cachyos/' bin/omarch
 sed -i '/run_logged \$OMARCHY_INSTALL\/preflight\/pacman\.sh/d' install/preflight/all.sh
 
 # Replace nvidia.sh with custom CachyOS 580xx Driver Logic
-cp ../bin/nvidia.sh install/config/hardware/nvidia.sh
+cp "$SCRIPT_DIR/nvidia.sh" install/config/hardware/nvidia.sh
 chmod +x install/config/hardware/nvidia.sh
 
 # Fix omarchy-ai-skill.sh symlink to be idempotent on re-runs
@@ -155,9 +162,9 @@ fi\
 sed -i 's/omarchy-cmd-present mise && eval "\$(mise activate bash)"/if [ "\$SHELL" = "\/bin\/bash" ] \&\& command -v mise \&> \/dev\/null; then\n  eval "\$(mise activate bash)"\nelif [ "\$SHELL" = "\/bin\/fish" ] \&\& command -v mise \&> \/dev\/null; then\n  mise activate fish | source\nfi/' config/uwsm/env
 
 # Copy omarchy installation files to ~/.local/share/omarchy
-mkdir -p ~/.local/share/omarchy
-cp -r . ~/.local/share/omarchy
-cd ~/.local/share/omarchy
+mkdir -p "$OMARCHY_INSTALL_DIR"
+cp -r . "$OMARCHY_INSTALL_DIR"
+cd "$OMARCHY_INSTALL_DIR"
 
 # Pause and prompt for acknowledgment to begin installation
 echo ""


### PR DESCRIPTION
## Summary
- move the Omarchy working tree into `.tmp/omarchy` inside this repository
- make the installer resolve helper scripts from `SCRIPT_DIR` instead of the caller's current directory
- export `OMARCHY_WORK_DIR` from the main installer so `fetch-omarchy.sh` uses a single shared source of truth

## Changes
| File | Change |
|------|--------|
| `.gitignore` | Ignore the new `.tmp/` working directory |
| `bin/install-omarchy-on-cachyos.sh` | Define explicit path variables, use script-local helper paths, and install from the shared work tree |
| `bin/fetch-omarchy.sh` | Require the exported `OMARCHY_WORK_DIR` and clone into the repo-local `.tmp/omarchy` path |

## Test Plan
- [x] `bash -n bin/install-omarchy-on-cachyos.sh`
- [x] `bash -n bin/fetch-omarchy.sh`
- [x] Manually verified the updated path flow end-to-end during local testing
- [ ] `shellcheck` (not available in the current environment)

## Notes
This fixes path handling that previously depended on the caller's current working directory and could clone or patch Omarchy in the wrong location.