### PR TITLE
feat: CachyOS compatibility improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # omarchy-on-cachyos
 
+- UPDATE 19-Jun-2026: Added system detection, optional autologin, email validation, guard bypass for ext4 and existing desktop environments. KDE/GNOME coexistence now supported.
 - UPDATE 20-May-2026: The install script now includes interactive version selection for choosing between Stable releases and Bleeding Edge.
 - UPDATE 1-October-2025: The install script has been updated to support Omarchy 3.0+ out of the box.
 
@@ -49,11 +50,11 @@ The philosophy behind this script is to produce a strong and stable blend of Cac
 
 IMPORTANT: This script does not install CachyOS. You must do that separately (and first.) This script is intended to be run on a fresh installation of CachyOS with the following configuration choices made: (Note, for information on installing CachyOS, please refer to https://www.cachyos.org.) 
 
-1. File System: You must choose BTRFS as the file system and Snapper as the snapshot manager. This aligns with CachyOS's default recommendation for most systems, and is required for Omarchy to properly function.
+1. File System: BTRFS is **not required** when using this script. The snapshot/rollback feature (`limine-snapper`) that Omarchy uses btrfs for is automatically disabled. **ext4, btrfs, and other filesystems are all supported.** The script will detect your filesystem at runtime and inform you of what is being skipped and why.
 
 2. Shell: You must choose Fish as the default shell for this installation script to work properly. (This is the default CachyOS shell choice.)
 
-3. Desktop Environment to Install: You can install a minimal system with no desktop environment or you can choose to install the CachyOS Hyprland Desktop Environment. If you have CachyOS install Hyprland, it will also install SDDM as the login display manager by default. Do not install GNOME or KDE.
+3. Desktop Environment to Install: You can install a minimal system with no desktop environment, the CachyOS Hyprland desktop, KDE Plasma, or GNOME. **KDE and GNOME are now supported** — Omarchy will install alongside your existing desktop and appear as a selectable session at login. You do not need to uninstall your current desktop environment.
 
 4. Graphics Drivers for NVIDIA users: 
 
@@ -110,6 +111,38 @@ chmod +x install-omarchy-on-cachyos.sh
 THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Use this script at your own risk. Always backup your system and important data before running installation scripts.
+
+## 7. CachyOS Compatibility Notes
+
+The following changes are made automatically by this script to resolve conflicts between CachyOS and Omarchy's default assumptions. The script will print a summary of what was detected and skipped on your specific system before the installation begins.
+
+| Issue | What the script does | Why |
+|---|---|---|
+| **Btrfs required** | Bypasses the guard; disables `limine-snapper` | CachyOS may use ext4 or other filesystems. Snapshot support is not required to use Omarchy. |
+| **KDE/GNOME detected** | Bypasses the guard; installs Omarchy as an additional session | Omarchy coexists with your existing desktop — you pick your session at login. |
+| **Autologin** | Asks you at install time: opt-in or opt-out | If you have KDE or another desktop, you likely want to choose your session at login rather than be auto-logged into Omarchy. |
+| **SDDM config conflict** | Removes `/etc/sddm.conf` if present | CachyOS's SDDM config conflicts with Omarchy's UWSM session autologin setup. |
+| **`tldr` conflict** | Removes `tldr` from Omarchy's package list | CachyOS ships Tealdeer (`tldr`), a Rust-based TLDR implementation. Installing both causes a conflict. |
+| **`wpa_supplicant` conflict** | Disables `wpa_supplicant`; sets NetworkManager to use `iwd` | CachyOS enables `wpa_supplicant` by default, which conflicts with Omarchy's `iwd`, causing WiFi to appear connected but have no IP. |
+| **`walker` version conflict** | Pins `walker` to the Omarchy repo via `IgnorePkg` | CachyOS ships a newer version of `walker` that is incompatible with Omarchy's `elephant` launcher. |
+| **pacman.conf changes** | Skips Omarchy's `pacman.sh` preflight and post-install | Omarchy's `pacman.sh` overwrites CachyOS-specific pacman settings. |
+| **Plymouth/bootloader** | Skips `plymouth.sh`, `limine-snapper.sh`, `alt-bootloaders.sh` | CachyOS manages its own bootloader. These scripts assume a fresh Arch install and would conflict with CachyOS's boot configuration. |
+| **NVIDIA drivers** | Only installs if no driver is already present | CachyOS may already have the correct NVIDIA driver installed. The script checks before acting. |
+
+### What `plymouth.sh` does (and when to run it manually)
+
+`plymouth.sh` sets the Omarchy boot splash theme. It is **skipped automatically** during install because:
+- If you have **KDE or GNOME**, your display manager already handles login — no action needed.
+- If you have **multi-boot** (e.g. a Windows partition), your bootloader and boot menu are unaffected. Plymouth only changes the splash animation on the Linux side.
+
+If you installed CachyOS **without any desktop environment** and want the Omarchy splash, run it manually after the install:
+```bash
+~/.local/share/omarchy/install/login/plymouth.sh
+```
+
+### Stable vs. Bleeding Edge
+
+The install script will ask you which version of Omarchy to install. For CachyOS users, **Stable (latest tag) is recommended**. The compatibility patches in this script are written against the current stable release. Bleeding edge may change install paths or script logic in ways that break the patches mid-install.
 
 ## 7. How to Contribute
 

--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -120,6 +120,45 @@ sed -i '/linux-cachyos/ ! s/pacman -Q linux/pacman -Q linux-cachyos/' bin/omarch
 # Remove pacman.sh from preflight/all.sh to prevent conflict with cachyos packages
 sed -i '/run_logged \$OMARCHY_INSTALL\/preflight\/pacman\.sh/d' install/preflight/all.sh
 
+# --- Detect system configuration ---
+DETECTED_FSTYPE=$(findmnt -n -o FSTYPE /)
+DETECTED_DE="None"
+if pacman -Qe plasma-desktop &>/dev/null; then
+    DETECTED_DE="KDE Plasma"
+elif pacman -Qe gnome-shell &>/dev/null; then
+    DETECTED_DE="GNOME"
+fi
+
+echo ""
+echo "System detection results:"
+echo "  Root filesystem : $DETECTED_FSTYPE"
+echo "  Desktop env     : $DETECTED_DE"
+echo ""
+
+# Explain what is being skipped and why, based on detection
+if [[ "$DETECTED_FSTYPE" != "btrfs" ]]; then
+    echo "  [SKIP] Btrfs filesystem guard:"
+    echo "         Your root filesystem is '$DETECTED_FSTYPE', not btrfs."
+    echo "         Omarchy uses btrfs only for snapshot/rollback support (limine-snapper)."
+    echo "         That feature is already disabled in this CachyOS install script."
+    echo "         The guard warning will be bypassed automatically."
+    echo ""
+fi
+
+if [[ "$DETECTED_DE" == "KDE Plasma" || "$DETECTED_DE" == "GNOME" ]]; then
+    echo "  [SKIP] Existing desktop environment guard:"
+    echo "         Omarchy detected '$DETECTED_DE' and would normally refuse to install."
+    echo "         This script supports installing Omarchy alongside your existing desktop."
+    echo "         You will be able to choose your session at login."
+    echo "         The guard warning will be bypassed automatically."
+    echo ""
+fi
+
+# Patch guard.sh to auto-proceed past guards that don't apply to CachyOS
+# Instead of removing the checks (which would hide real problems), we stub out
+# the abort() function so it prints the warning but never prompts or exits.
+sed -i 's/^abort() {$/abort() {\n  echo -e "\\e[33m[CachyOS Compat] Warning bypassed: $1\\e[0m"\n  return 0\n  # Original abort body below (disabled):/' install/preflight/guard.sh
+
 # Replace nvidia.sh with custom CachyOS 580xx Driver Logic
 cp "$SCRIPT_DIR/nvidia.sh" install/config/hardware/nvidia.sh
 chmod +x install/config/hardware/nvidia.sh
@@ -138,11 +177,34 @@ sed -i '/run_logged \$OMARCHY_INSTALL\/login\/alt-bootloaders\.sh/d' install/log
 
 # Make autologin optional
 if [[ ! "${ENABLE_AUTOLOGIN,,}" =~ ^(y|yes)$ ]]; then
-    # Remove autologin configuration from Omarchy's SDDM setup
-    sed -i '/\[Autologin\]/d' install/login/sddm.sh
-    sed -i '/User=\$USER/d' install/login/sddm.sh
-    sed -i '/Session=omarchy/d' install/login/sddm.sh
-    
+    # Replace the entire autologin if/else block with a clean no-autologin version.
+    # We use python to rewrite the file safely, avoiding broken heredoc/if-block syntax
+    # that results from deleting individual lines with sed.
+    python3 - install/login/sddm.sh << 'PYEOF'
+import sys, re
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+# Replace the autologin if/else block with just the theme-only conf
+old_block = re.search(
+    r"if \[\[.*autologin\.conf.*?\]\];.*?^fi$",
+    content, re.DOTALL | re.MULTILINE
+)
+if old_block:
+    replacement = (
+        "# Set SDDM theme without autologin (user opted out during install)\n"
+        "cat <<EOF | sudo tee /etc/sddm.conf.d/omarchy-theme.conf > /dev/null\n"
+        "[Theme]\n"
+        "Current=omarchy\n"
+        "EOF"
+    )
+    content = content[:old_block.start()] + replacement + content[old_block.end():]
+
+with open(sys.argv[1], 'w') as f:
+    f.write(content)
+PYEOF
+
     # Remove any existing autologin conf so SDDM prompts for password
     sudo rm -f /etc/sddm.conf.d/autologin.conf 2>/dev/null
 fi

--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -11,9 +11,9 @@ echo "Fetching Omarchy source..."
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OMARCHY_DIR="$SCRIPT_DIR/../../omarchy"
 
-if [ -f "./fetch-omarchy.sh" ]; then
-    chmod +x ./fetch-omarchy.sh
-    ./fetch-omarchy.sh
+if [ -f "$SCRIPT_DIR/fetch-omarchy.sh" ]; then
+    chmod +x "$SCRIPT_DIR/fetch-omarchy.sh"
+    "$SCRIPT_DIR/fetch-omarchy.sh"
 else
     # Fallback if script is missing
     echo "fetch-omarchy.sh not found, falling back to default clone..."
@@ -73,22 +73,41 @@ fi
 
 # Prompt user for username
 echo ""
-echo "Please enter your username:"
+echo "Please enter your name for git commits (e.g. John Doe)."
+echo "This also sets a CapsLock+Space+N shortcut to type it quickly."
 read -r OMARCHY_USER_NAME
 export OMARCHY_USER_NAME
 
 # Prompt user for email address
 echo ""
-echo "Please enter your email address:"
-read -r OMARCHY_USER_EMAIL
+echo "Please enter your email for git commits (e.g. you@example.com)."
+echo "This also sets a CapsLock+Space+E shortcut to type it quickly. Leave blank to skip."
+echo "(Stays on your machine only — not sent anywhere, no newsletters, no telemetry.)"
+while true; do
+    read -r OMARCHY_USER_EMAIL
+    if [[ -z "$OMARCHY_USER_EMAIL" ]]; then
+        echo "Skipping email configuration."
+        break
+    elif [[ "$OMARCHY_USER_EMAIL" =~ ^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$ ]]; then
+        break
+    else
+        echo "Invalid email format. Please try again (or leave blank to skip):"
+    fi
+done
 export OMARCHY_USER_EMAIL
+
+# Prompt user for autologin preference
+echo ""
+echo "Do you want to enable automatic login to Omarchy?"
+echo "If 'no', you will be prompted for a password at boot and can choose your desktop environment (e.g. KDE)."
+read -r -p "[y/N]: " ENABLE_AUTOLOGIN
 
 # Make adjustments to Omarchy install scripts to support CachyOS
 echo ""
 echo "Making adjustments to Omarchy install scripts to support CachyOS..."
 
 # Navigate to Omarchy install scripts
-cd ../omarchy
+cd "$OMARCHY_DIR" || { echo "Error: failed to change directory to $OMARCHY_DIR"; exit 1; }
 
 # Remove tldr installation to prevent conflict with tealdeer install.
 sed -i '/tldr/d' install/omarchy-base.packages
@@ -102,7 +121,7 @@ sed -i '/linux-cachyos/ ! s/pacman -Q linux/pacman -Q linux-cachyos/' bin/omarch
 sed -i '/run_logged \$OMARCHY_INSTALL\/preflight\/pacman\.sh/d' install/preflight/all.sh
 
 # Replace nvidia.sh with custom CachyOS 580xx Driver Logic
-cp ../bin/nvidia.sh install/config/hardware/nvidia.sh
+cp "$SCRIPT_DIR/nvidia.sh" install/config/hardware/nvidia.sh
 chmod +x install/config/hardware/nvidia.sh
 
 # Fix omarchy-ai-skill.sh symlink to be idempotent on re-runs
@@ -116,6 +135,17 @@ sed -i '/run_logged \$OMARCHY_INSTALL\/login\/limine-snapper\.sh/d' install/logi
 
 # Remove alt-bootloaders.sh source line from install.sh
 sed -i '/run_logged \$OMARCHY_INSTALL\/login\/alt-bootloaders\.sh/d' install/login/all.sh
+
+# Make autologin optional
+if [[ ! "${ENABLE_AUTOLOGIN,,}" =~ ^(y|yes)$ ]]; then
+    # Remove autologin configuration from Omarchy's SDDM setup
+    sed -i '/\[Autologin\]/d' install/login/sddm.sh
+    sed -i '/User=\$USER/d' install/login/sddm.sh
+    sed -i '/Session=omarchy/d' install/login/sddm.sh
+    
+    # Remove any existing autologin conf so SDDM prompts for password
+    sudo rm -f /etc/sddm.conf.d/autologin.conf 2>/dev/null
+fi
 
 # Remove pacman.sh from post-install/all.sh to prevent conflict with cachyos packages
 sed -i '/run_logged \$OMARCHY_INSTALL\/post-install\/pacman\.sh/d' install/post-install/all.sh
@@ -155,6 +185,7 @@ fi\
 sed -i 's/omarchy-cmd-present mise && eval "\$(mise activate bash)"/if [ "\$SHELL" = "\/bin\/bash" ] \&\& command -v mise \&> \/dev\/null; then\n  eval "\$(mise activate bash)"\nelif [ "\$SHELL" = "\/bin\/fish" ] \&\& command -v mise \&> \/dev\/null; then\n  mise activate fish | source\nfi/' config/uwsm/env
 
 # Copy omarchy installation files to ~/.local/share/omarchy
+rm -rf ~/.local/share/omarchy
 mkdir -p ~/.local/share/omarchy
 cp -r . ~/.local/share/omarchy
 cd ~/.local/share/omarchy
@@ -169,15 +200,25 @@ echo " 4. Replaced nvidia.sh to respect existing CachyOS NVIDIA drivers (only in
 echo " 5. Removed plymouth.sh from install.sh to avoid conflict with CachyOS login display manager installation."
 echo " 6. Removed limine-snapper.sh from install.sh to avoid conflict with CachyOS boot loader installation."
 echo " 7. Removed alt-bootloaders.sh from install.sh to avoid conflict with CachyOS boot loader installation."
-echo " 8. Removed /etc/sddm.conf to avoid conflict with Omarchy UWSM session autologin."
+if [[ "${ENABLE_AUTOLOGIN,,}" =~ ^(y|yes)$ ]]; then
+    echo " 8. Removed /etc/sddm.conf and configured Omarchy SDDM autologin."
+else
+    echo " 8. Removed /etc/sddm.conf and disabled Omarchy SDDM autologin."
+fi
 echo " 9. Disabled wpa_supplicant and configured NetworkManager to use iwd backend."
 echo "10. Pinned walker to omarchy repo to prevent CachyOS version conflict."
 echo ""
-echo "IMPORTANT: If you installed CachyOS without a deskop environment, you will not have a display manager installed." 
+echo "IMPORTANT: If you installed CachyOS without a desktop environment, you will not have a display manager installed."
 echo "If this is the case, you will need to run the following command after this installation script is complete:"
-echo " 1.) ~/.local/share/omarchy/install/login/plymouth.sh"  
+echo "  ~/.local/share/omarchy/install/login/plymouth.sh"
 echo ""
-echo "The aboves script will modify your boot to start Omarchy's Hyprland desktop automatically." 
+echo "That script only sets the Omarchy boot splash (Plymouth theme). It does NOT change your bootloader."
+echo ""
+echo "  - Already have KDE or GNOME? No action needed — your existing login screen and desktop are untouched."
+echo "    Omarchy will appear as a selectable session in your display manager (e.g. SDDM)."
+echo ""
+echo "  - Multi-boot with Windows? Safe — this script does not modify GRUB or your boot entries."
+echo "    Your Windows partition and boot menu remain exactly as they are."
 echo ""
 echo "Press Enter to begin the installation of Omarchy..."
 read -r

--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -177,32 +177,16 @@ sed -i '/run_logged \$OMARCHY_INSTALL\/login\/alt-bootloaders\.sh/d' install/log
 
 # Make autologin optional
 if [[ ! "${ENABLE_AUTOLOGIN,,}" =~ ^(y|yes)$ ]]; then
-    # Replace the entire autologin if/else block with a clean no-autologin version.
-    # We use python to rewrite the file safely, avoiding broken heredoc/if-block syntax
-    # that results from deleting individual lines with sed.
+    # Replace the entire sddm.sh script with a minimal version.
+    # We only want to copy the wayland-sessions file so Omarchy appears in the SDDM dropdown.
+    # We do NOT want to install the Omarchy theme, force the Wayland greeter, or edit PAM.
     python3 - install/login/sddm.sh << 'PYEOF'
-import sys, re
-
-with open(sys.argv[1]) as f:
-    content = f.read()
-
-# Replace the autologin if/else block with just the theme-only conf
-old_block = re.search(
-    r"if \[\[.*autologin\.conf.*?\]\];.*?^fi$",
-    content, re.DOTALL | re.MULTILINE
-)
-if old_block:
-    replacement = (
-        "# Set SDDM theme without autologin (user opted out during install)\n"
-        "cat <<EOF | sudo tee /etc/sddm.conf.d/omarchy-theme.conf > /dev/null\n"
-        "[Theme]\n"
-        "Current=omarchy\n"
-        "EOF"
-    )
-    content = content[:old_block.start()] + replacement + content[old_block.end():]
-
+import sys
 with open(sys.argv[1], 'w') as f:
-    f.write(content)
+    f.write("""# Minimal SDDM setup (user opted out of Omarchy autologin/theme)
+sudo mkdir -p /usr/local/share/wayland-sessions
+sudo cp "$OMARCHY_PATH/default/wayland-sessions/omarchy.desktop" /usr/local/share/wayland-sessions/omarchy.desktop
+""")
 PYEOF
 
     # Remove any existing autologin conf so SDDM prompts for password


### PR DESCRIPTION
Fixes and improvements to the install script for CachyOS compatibility:

- fix: use absolute paths for scripts and target directories (fixes "No such file or directory" crash)
- fix: remove stale ~/.local/share/omarchy before copying to avoid permission denied errors on re-runs
- feat: make Omarchy autologin optional — users with KDE/GNOME can keep their existing login screen
- feat: add email format validation with retry loop; allow skipping email
- feat: clarify prompts — explain what name/email are used for (git config + keyboard shortcuts, nothing else)
- feat: expand IMPORTANT notice to clarify KDE/GNOME and multi-boot (Windows) users are unaffected by plymouth.sh
- fix: typos ("deskop", "aboves")
