### PR TITLE
Fix navigation path in install script for CachyOS

### DIFF
--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -87,8 +87,8 @@ export OMARCHY_USER_EMAIL
 echo ""
 echo "Making adjustments to Omarchy install scripts to support CachyOS..."
 
-# Navigate to Omarchy install scripts
-cd ../omarchy
+# Navigate to Omarchy install scripts 
+cd "$HOME/omarchy"
 
 # Remove tldr installation to prevent conflict with tealdeer install.
 sed -i '/tldr/d' install/omarchy-base.packages


### PR DESCRIPTION
Updated script to navigaScript updated to navigate to the Omarchy directory using the HOME variable.
- One issue I've encountered is that the installation script fails to locate the path for `install.sh` within the Omarchy directory. I am unsure if this is because the official Omarchy repository needs to be loaded via the `omarchy-on-cachyos` repository and the steps in `install-omarchy-on-cachyos.sh` must be followed. By using the `$HOME` variable this way, the script will navigate directly to the required folder path to proceed with the subsequent steps. I would appreciate any help or explanation; thank you very much.te to the Omarchy directory using the HOME variable.