### PR TITLE
Fix: use $OMARCHY_DIR instead of hardcoded relative path ../omarchy

### DIFF
--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -88,7 +88,7 @@ echo ""
 echo "Making adjustments to Omarchy install scripts to support CachyOS..."
 
 # Navigate to Omarchy install scripts
-cd ../omarchy
+cd "$OMARCHY_DIR"
 
 # Remove tldr installation to prevent conflict with tealdeer install.
 sed -i '/tldr/d' install/omarchy-base.packages


### PR DESCRIPTION
The script defines OMARCHY_DIR at the top as $SCRIPT_DIR/../../omarchy, correctly pointing to the omarchy directory which sits at the same level as omarchy-on-cachyos.

However, line 91 uses `cd ../omarchy` which only goes up one directory level, landing inside omarchy-on-cachyos instead of the correct omarchy directory.

This causes the subsequent sed commands to target wrong files, breaking the installation. Using `cd "$OMARCHY_DIR"` ensures the correct path is used regardless of where the script is invoked from.