### PR TITLE
Modify navigation to Omarchy directory with error check and use of $OARCHY_DIR variable

### DIFF
--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -88,7 +88,10 @@ echo ""
 echo "Making adjustments to Omarchy install scripts to support CachyOS..."
 
 # Navigate to Omarchy install scripts
-cd ../omarchy
+cd "$OMARCHY_DIR" || {
+	echo "ERROR: Cannot find Omarchy at $OMARCHY_DIR"
+	exit 1
+}
 
 # Remove tldr installation to prevent conflict with tealdeer install.
 sed -i '/tldr/d' install/omarchy-base.packages


### PR DESCRIPTION
Updated script to navigate to Omarchy directory using a variable and added error handling. Use the variable set to navigate to omarchy to actually move to the omarchy instalation directory so it reads the files correctly