### PR TITLE
fix: use absolute Omarchy path after fetch

### DIFF
--- a/bin/install-omarchy-on-cachyos.sh
+++ b/bin/install-omarchy-on-cachyos.sh
@@ -87,8 +87,12 @@ export OMARCHY_USER_EMAIL
 echo ""
 echo "Making adjustments to Omarchy install scripts to support CachyOS..."
 
-# Navigate to Omarchy install scripts
-cd ../omarchy
+# Navigate to Omarchy install scripts (same path fetch-omarchy.sh clones into)
+if [ ! -d "$OMARCHY_DIR" ]; then
+    echo "Error: Omarchy source not found at $OMARCHY_DIR"
+    exit 1
+fi
+cd "$OMARCHY_DIR"
 
 # Remove tldr installation to prevent conflict with tealdeer install.
 sed -i '/tldr/d' install/omarchy-base.packages
@@ -102,7 +106,7 @@ sed -i '/linux-cachyos/ ! s/pacman -Q linux/pacman -Q linux-cachyos/' bin/omarch
 sed -i '/run_logged \$OMARCHY_INSTALL\/preflight\/pacman\.sh/d' install/preflight/all.sh
 
 # Replace nvidia.sh with custom CachyOS 580xx Driver Logic
-cp ../bin/nvidia.sh install/config/hardware/nvidia.sh
+cp "$SCRIPT_DIR/nvidia.sh" install/config/hardware/nvidia.sh
 chmod +x install/config/hardware/nvidia.sh
 
 # Fix omarchy-ai-skill.sh symlink to be idempotent on re-runs


### PR DESCRIPTION
## Summary

- `fetch-omarchy.sh` clones Omarchy into `$SCRIPT_DIR/../../omarchy` (also set as `OMARCHY_DIR` in the install script).
- The install script then ran `cd ../omarchy` from `bin/`, which resolves to `$REPO/omarchy`, not `$SCRIPT_DIR/../../omarchy`.
- That mismatch causes the CachyOS sed/cp steps to run in the wrong (or missing) tree after a successful clone.
- Also copy `nvidia.sh` via `$SCRIPT_DIR` so the path still works after entering `OMARCHY_DIR`.

## Test plan

- [ ] Fresh clone of this repo under a normal home path (e.g. `~/omarchy-on-cachyos`)
- [ ] Run `bin/install-omarchy-on-cachyos.sh` through the fetch + “Making adjustments…” section
- [ ] Confirm it enters the same directory that was cloned and that `install/config/hardware/nvidia.sh` is written from this repo’s `bin/nvidia.sh`
- [ ] Confirm no `cd: ../omarchy: No such file or directory` / missing `install/omarchy-base.packages` errors at that stage